### PR TITLE
Fix CI pnpm setup version conflict

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
-        with:
-          version: 9
       - uses: actions/setup-node@v4
         with:
           node-version: 22


### PR DESCRIPTION
## What changed

- Removed the duplicate pnpm version from the Actions workflow.
- pnpm/action-setup now reads the exact pnpm@9.15.9 version already pinned by package.json.

## Why

Every CI run currently stops during pnpm/action-setup because the workflow requests version 9 while package.json requests pnpm@9.15.9. The action rejects the two version sources before dependencies are installed. Keeping packageManager as the single source of truth unblocks the rest of the pipeline and prevents version drift.

## Validation

- Workflow YAML parses successfully
- pnpm install --frozen-lockfile (pnpm 9.15.9)
- pnpm typecheck
- pnpm test (90 tests passed)
- pnpm build